### PR TITLE
Registered versions with modrinth

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ group=com.mrbysco.durabilitynotifier
 
 # Common
 minecraft_version=26.1
+supported_minecraft_versions=26.1,26.1.1,26.1.2
 neoform_version=26.1-1
 mixin_version=0.16.5+mixin.0.8.7
 mixinextras_version=0.5.3

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -125,7 +125,7 @@ if (System.getenv().MODRINTH_KEY) {
         versionNumber = project.version
         uploadFile = jar
         changelog = file("$project.rootDir/changelog.md").text
-        gameVersions = ["${minecraft_version}"]
+        gameVersions = List.of(supported_minecraft_versions.split(","))
         loaders = ["neoforge"]
     }
 }


### PR DESCRIPTION
Launchers don't see the version since modrinth only returns 26.1 this should add versions for modrinth